### PR TITLE
Bug Fixes

### DIFF
--- a/Sources/BJOTPViewController/Custom Views/BJOTPTextField.swift
+++ b/Sources/BJOTPViewController/Custom Views/BJOTPTextField.swift
@@ -32,4 +32,8 @@ final class BJOTPTextField: UITextField {
     override func caretRect(for position: UITextPosition) -> CGRect {
         return .init(origin: .init(x: self.bounds.midX, y: self.bounds.origin.y), size: .init(width: 0.1, height: 0.1))
     }
+    
+    override func closestPosition(to point: CGPoint) -> UITextPosition? {
+        return self.endOfDocument
+    }
 }


### PR DESCRIPTION
**Changes:**

- `viewDidAppear` bug that replaces textfields with "" - FIXED.
- A bug where erasing existing content from textfield won't move the responder status to previous textfield - FIXED.
- Removed added observers.
- Small changes in documentation.